### PR TITLE
Introduce SubProcess.join()

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ you can do that by passing a second parameter in milliseconds to `start()`:
 await proc.start(null, 1000);
 ```
 
+After the process has been started you can use `join()` to wait for it:
+
+```js
+await proc.join(); // will throw on exitcode not 0
+await proc.join([0, 1]); // will throw on exitcode not 0 or 1
+```
+
 And how about killing the processes? Can you provide a custom signal, instead
 of using the default `SIGTERM`? Why yes:
 

--- a/lib/teen_process.js
+++ b/lib/teen_process.js
@@ -220,6 +220,22 @@ class SubProcess extends EventEmitter {
       }, timeout);
     });
   }
+
+  async join (allowedExitCodes = [0]) {
+    if (!this.proc) {
+      throw new Error("Can't join process; it's not currently running");
+    }
+
+    return new Promise((resolve, reject) => {
+      this.proc.on('exit', (code) => {
+        if (allowedExitCodes.indexOf(code) === -1) {
+          reject(new Error(`Process ended with exitcode ${code}`));
+        } else {
+          resolve(code);
+        }
+      });
+    });
+  }
 }
 
 export { exec, spawn, SubProcess };

--- a/test/subproc-specs.js
+++ b/test/subproc-specs.js
@@ -182,4 +182,32 @@ describe('SubProcess', () => {
       await subproc.stop().should.eventually.be.rejectedWith(/Can't stop/);
     });
   });
+
+  describe('#join', () => {
+    it('should fail if the #start has not yet been called', async () => {
+      const proc = new SubProcess(getFixture('sleepyproc.sh'), ['ls']);
+      await proc.join().should.eventually.be.rejectedWith(/Can't join/);
+    });
+
+    it('should wait until the process has been finished', async () => {
+      const proc = new SubProcess(getFixture('sleepyproc.sh'), ['ls']);
+      const now = Date.now();
+      await proc.start(0);
+      await proc.join();
+      const diff = Date.now() - now;
+      diff.should.be.above(1000);
+    });
+
+    it('should throw if process ends with a invalid exitcode', async () => {
+      const proc = new SubProcess(getFixture('bad_exit.sh'));
+      await proc.start(0);
+      await proc.join().should.eventually.be.rejectedWith(/Process ended with exitcode/);
+    });
+
+    it('should NOT throw if process ends with a custom allowed exitcode', async () => {
+      const proc = new SubProcess(getFixture('bad_exit.sh'));
+      await proc.start(0);
+      await proc.join([1]).should.eventually.be.become(1);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a new method to `SubProcess` called `join()`. It can be used to wait for the process to finish - it's, IMHO, the missing piece between `start()` and `stop()`. 