### PR TITLE
Fixed Windows tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lib": "lib"
   },
   "dependencies": {
+    "appium-support": "^2.0.10",
     "babel-runtime": "=5.8.24",
     "shell-quote": "^1.4.3",
     "source-map-support": "^0.2.10",

--- a/test/exec-specs.js
+++ b/test/exec-specs.js
@@ -4,7 +4,8 @@ import path from 'path';
 import { exec } from '..';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { getFixture, system } from './helpers';
+import { getFixture } from './helpers';
+import { system } from 'appium-support';
 
 const should = chai.should();
 chai.use(chaiAsPromised);

--- a/test/exec-specs.js
+++ b/test/exec-specs.js
@@ -4,8 +4,7 @@ import path from 'path';
 import { exec } from '..';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { getFixture } from './helpers';
-
+import { getFixture, system } from './helpers';
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -21,7 +20,7 @@ describe('exec', () => {
   });
 
   it('should throw an error with a bad exit code', async () => {
-    let cmd = getFixture("bad_exit.sh");
+    let cmd = getFixture("bad_exit");
     let err;
     try {
       await exec(cmd);
@@ -35,7 +34,7 @@ describe('exec', () => {
   });
 
   it('should work with spaces in arguments', async () => {
-    let cmd = getFixture("echo.sh");
+    let cmd = getFixture("echo");
     let echo1 = "my name is bob";
     let echo2 = "lol";
     let {stdout, stderr, code} = await exec(cmd, [echo1, echo2]);
@@ -45,7 +44,7 @@ describe('exec', () => {
   });
 
   it('should work with backslashes in arguments', async () => {
-    let cmd = getFixture("echo.sh");
+    let cmd = getFixture("echo");
     let echo1 = "my\\ name\\ is\\ bob";
     let echo2 = "lol";
     let {stdout, stderr, code} = await exec(cmd, [echo1, echo2]);
@@ -55,7 +54,17 @@ describe('exec', () => {
   });
 
   it('should work with spaces in commands', async () => {
-    let cmd = getFixture("echo with space.sh");
+    let cmd = getFixture("echo with space");
+    let echo1 = "bobbob";
+    let echo2 = "lol";
+    let {stdout, stderr, code} = await exec(cmd, [echo1, echo2]);
+    stdout.trim().should.equal(echo1);
+    stderr.trim().should.equal(echo2);
+    code.should.equal(0);
+  });
+
+  it('should work with spaces in commands and arguments', async () => {
+    let cmd = getFixture("echo with space");
     let echo1 = "my name is bob";
     let echo2 = "lol";
     let {stdout, stderr, code} = await exec(cmd, [echo1, echo2]);
@@ -65,10 +74,10 @@ describe('exec', () => {
   });
 
   it('should respect cwd', async () => {
-    let cmd = "./echo.sh";
+    let cmd = system.isWindows() ? "echo.bat" : "./echo.sh";
     let echo1 = "my name is bob";
     let echo2 = "lol";
-    let cwd = path.dirname(getFixture("echo.sh"));
+    let cwd = path.dirname(getFixture("echo"));
     let {stdout, stderr, code} = await exec(cmd, [echo1, echo2], {cwd});
     stdout.trim().should.equal(echo1);
     stderr.trim().should.equal(echo2);
@@ -76,7 +85,7 @@ describe('exec', () => {
   });
 
   it('should respect env', async () => {
-    let cmd = getFixture("env.sh");
+    let cmd = getFixture("env");
     let env = {FOO: "lolol"};
     let {stdout, code} = await exec(cmd, [], {env});
     stdout.trim().should.equal(`${env.FOO} ${env.FOO}`);
@@ -111,4 +120,3 @@ describe('exec', () => {
     code.should.equal(0);
   });
 });
-

--- a/test/fixtures/bad_exit.bat
+++ b/test/fixtures/bad_exit.bat
@@ -1,0 +1,4 @@
+@echo off
+echo foo
+1>&2 echo bar
+exit 1

--- a/test/fixtures/echo with space.bat
+++ b/test/fixtures/echo with space.bat
@@ -1,0 +1,3 @@
+@echo off
+echo %~1
+1>&2 echo %~2

--- a/test/fixtures/echo.bat
+++ b/test/fixtures/echo.bat
@@ -1,0 +1,3 @@
+@echo off
+echo %~1
+1>&2 echo %~2

--- a/test/fixtures/env.bat
+++ b/test/fixtures/env.bat
@@ -1,0 +1,2 @@
+@echo off
+echo %FOO% %FOO%

--- a/test/fixtures/sleepyproc.bat
+++ b/test/fixtures/sleepyproc.bat
@@ -1,0 +1,3 @@
+@echo off
+SLEEP 1
+echo $*

--- a/test/fixtures/traphup.bat
+++ b/test/fixtures/traphup.bat
@@ -1,0 +1,3 @@
+@echo off
+trap "trapped!" SIGTERM
+%*

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,4 +9,4 @@ function getFixture (fix) {
   return path.resolve(__dirname, "..", "..", "test", "fixtures", fix);
 }
 
-export { getFixture, system };
+export { getFixture };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,8 +1,12 @@
 import path from 'path';
+import { system } from 'appium-support';
 
 function getFixture (fix) {
+  // Append .bat or .sh is there's no extention
+  if (fix.indexOf('.') === -1) {
+    fix = fix + (system.isWindows() ? '.bat' : '.sh');
+  }
   return path.resolve(__dirname, "..", "..", "test", "fixtures", fix);
 }
 
-export { getFixture };
-
+export { getFixture, system };

--- a/test/subproc-specs.js
+++ b/test/subproc-specs.js
@@ -5,7 +5,9 @@ import path from 'path';
 import { exec, SubProcess } from '..';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { getFixture, system } from './helpers';
+import { getFixture } from './helpers';
+import { system } from 'appium-support';
+
 
 // Windows doesn't understand SIGHUP
 let stopSignal = system.isWindows() ? 'SIGTERM' : 'SIGHUP';

--- a/test/subproc-specs.js
+++ b/test/subproc-specs.js
@@ -5,9 +5,10 @@ import path from 'path';
 import { exec, SubProcess } from '..';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { getFixture } from './helpers';
+import { getFixture, system } from './helpers';
 
-
+// Windows doesn't understand SIGHUP
+let stopSignal = system.isWindows() ? 'SIGTERM' : 'SIGHUP';
 const should = chai.should();
 chai.use(chaiAsPromised);
 
@@ -76,7 +77,7 @@ describe('SubProcess', () => {
     });
     it('should interpret a numeric startDetector as a start timeout', async () => {
       let hasData = false;
-      let s = new SubProcess(getFixture('sleepyproc.sh'), ['ls']);
+      let s = new SubProcess(getFixture('sleepyproc'), ['ls']);
       s.on('output', (stdout) => {
         if (stdout) {
           hasData = true;
@@ -121,7 +122,7 @@ describe('SubProcess', () => {
     let subproc;
     it('should get output as params', async () => {
       await new Promise(async (resolve) => {
-        subproc = new SubProcess(getFixture('sleepyproc.sh'),
+        subproc = new SubProcess(getFixture('sleepyproc'),
                                  ['ls', path.resolve(__dirname)]);
         subproc.on('output', (stdout) => {
           if (stdout && stdout.indexOf('subproc-specs') !== -1) {
@@ -133,7 +134,7 @@ describe('SubProcess', () => {
       await subproc.stop();
 
       await new Promise(async (resolve) => {
-        subproc = new SubProcess(getFixture('echo.sh'), ['foo', 'bar']);
+        subproc = new SubProcess(getFixture('echo'), ['foo', 'bar']);
         subproc.on('output', (stdout, stderr) => {
           if (stderr && stderr.indexOf('bar') !== -1) {
             resolve();
@@ -164,21 +165,21 @@ describe('SubProcess', () => {
         await subproc.start();
         subproc.on('exit', (code, signal) => {
           try {
-            signal.should.equal('SIGHUP');
+            signal.should.equal(stopSignal);
             resolve();
           } catch (e) {
             reject(e);
           }
         });
-        await subproc.stop('SIGHUP');
+        await subproc.stop(stopSignal);
       });
     });
 
     it('should time out if stop doesnt complete fast enough', async () => {
-      let subproc = new SubProcess(getFixture('traphup.sh'),
+      let subproc = new SubProcess(getFixture('traphup'),
                                    ['tail', '-f', path.resolve(__filename)]);
       await subproc.start();
-      await subproc.stop('SIGHUP', 10)
+      await subproc.stop(stopSignal, 1)
               .should.eventually.be.rejectedWith(/Process didn't end/);
 
       // need to kill the process
@@ -207,7 +208,7 @@ describe('SubProcess', () => {
     });
 
     it('should wait until the process has been finished', async () => {
-      const proc = new SubProcess(getFixture('sleepyproc.sh'), ['ls']);
+      const proc = new SubProcess(getFixture('sleepyproc'), ['ls']);
       const now = Date.now();
       await proc.start(0);
       await proc.join();
@@ -216,13 +217,13 @@ describe('SubProcess', () => {
     });
 
     it('should throw if process ends with a invalid exitcode', async () => {
-      const proc = new SubProcess(getFixture('bad_exit.sh'));
+      const proc = new SubProcess(getFixture('bad_exit'));
       await proc.start(0);
       await proc.join().should.eventually.be.rejectedWith(/Process ended with exitcode/);
     });
 
     it('should NOT throw if process ends with a custom allowed exitcode', async () => {
-      const proc = new SubProcess(getFixture('bad_exit.sh'));
+      const proc = new SubProcess(getFixture('bad_exit'));
       await proc.start(0);
       await proc.join([1]).should.eventually.be.become(1);
     });


### PR DESCRIPTION
This PR addresses most of the windows issues.

Windows still has a hard time `.spawn`ing if both the cmd path and an argument contain spaces.

There are no quick-fixes that suit us at this stage without rewriting how we handle processes. Looks like it has recently been addressed: https://github.com/nodejs/node/pull/4598

Resolves #6

CC @imurchie 

