### PR TITLE
Add error handling on standard streams

### DIFF
--- a/lib/teen_process.js
+++ b/lib/teen_process.js
@@ -30,6 +30,15 @@ function exec (cmd, args = [], opts = {}) {
     proc.on('error', (err) => {
       reject(new Error(`Command '${rep}' errored out: ${err.stack}`));
     });
+    proc.stdin.on('error', (err) => {
+      reject(new Error(`Standard input '${err.syscall}' error: ${err.stack}`));
+    });
+    proc.stdout.on('error', (err) => {
+      reject(new Error(`Standard output '${err.syscall}' error: ${err.stack}`));
+    });
+    proc.stderr.on('error', (err) => {
+      reject(new Error(`Standard error '${err.syscall}' error: ${err.stack}`));
+    });
 
     // keep track of stdout/stderr if we haven't said not to
     if (!opts.ignoreOutput) {


### PR DESCRIPTION
Get better handling of errors in the stdio streams within `exec`. I'm hoping this provides better support for EPIPE errors that sometimes crop up.