### PR TITLE
Get rid of start detector after start has been detected

### DIFF
--- a/lib/teen_process.js
+++ b/lib/teen_process.js
@@ -136,6 +136,7 @@ class SubProcess extends EventEmitter {
         // reject and move on from start
         try {
           if (startDetector && startDetector(data.stdout, data.stderr)) {
+            startDetector = null;
             resolve();
           }
         } catch (e) {


### PR DESCRIPTION
Otherwise after the process has started, if the start detector does any sort of logging we can get log lines that are confusing.