### PR TITLE
Add isRunning getter to SubProcess

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
+  - "6"

--- a/lib/teen_process.js
+++ b/lib/teen_process.js
@@ -100,6 +100,11 @@ class SubProcess extends EventEmitter {
     this.opts = opts;
   }
 
+  get isRunning () {
+    // presence of `proc` means we have connected and started
+    return !!this.proc;
+  }
+
   // spawn the subprocess and return control whenever we deem that it has fully
   // "started"
   async start (startDetector = null, timeoutMs = null) {
@@ -222,7 +227,7 @@ class SubProcess extends EventEmitter {
   }
 
   async stop (signal = 'SIGTERM', timeout = 10000) {
-    if (!this.proc) {
+    if (!this.isRunning) {
       throw new Error("Can't stop process; it's not currently running");
     }
     // make sure to emit any data in our lines buffer whenever we're done with


### PR DESCRIPTION
In calling code we keep having to do things like `if (sp.proc) sp.stop();` The calling code should not depend on internal details of the implementation of `SubProcess`. So add a method to check if it is running.