### PR TITLE
Add cmd to stop failure notice

### DIFF
--- a/lib/teen_process.js
+++ b/lib/teen_process.js
@@ -228,7 +228,7 @@ class SubProcess extends EventEmitter {
 
   async stop (signal = 'SIGTERM', timeout = 10000) {
     if (!this.isRunning) {
-      throw new Error("Can't stop process; it's not currently running");
+      throw new Error(`Can't stop process; it's not currently running (cmd: '${this.cmd}')`);
     }
     // make sure to emit any data in our lines buffer whenever we're done with
     // the proc
@@ -243,7 +243,7 @@ class SubProcess extends EventEmitter {
   }
 
   async join (allowedExitCodes = [0]) {
-    if (!this.proc) {
+    if (!this.isRunning) {
       throw new Error("Can't join process; it's not currently running");
     }
 

--- a/test/fixtures/bad_exit.sh
+++ b/test/fixtures/bad_exit.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 echo "foo"
+sleep 1s
 1>&2 echo "bar"
 exit 1


### PR DESCRIPTION
As a first step to figuring out where the deprecation warning are coming from when processes cannot be stopped, add the cmd that is the basis of the process to the error message.

@jlipps 