### PR TITLE
Add an option to turn spawned processes into not daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ let {stdout, stderr} = await exec('cat', [filename], {isBuffer: true});
 Buffer.isBuffer(stdout); // true
 ```
 
+The spawned process will be automatically terminated by receiving `SIGTERM`
+if `isDaemon` option is falsy and NodeJS event loop is terminated.
+
 ### teen_process.SubProcess
 
 `spawn` is already pretty great but for some uses there's a fair amount of

--- a/lib/teen_process.js
+++ b/lib/teen_process.js
@@ -19,6 +19,7 @@ function exec (cmd, args = [], opts = {}) {
     ignoreOutput: false,
     stdio: "inherit",
     isBuffer: false,
+    isDaemon: true,
   }, opts);
 
   // this is an async function, so return a promise
@@ -85,6 +86,19 @@ function exec (cmd, args = [], opts = {}) {
       }
     });
 
+    // kill the child process automatically if the IPC channel with the parent
+    // process is terminated and isDaemon property is not true
+    if (!opts.isDaemon) {
+      proc.on('disconnect', () => {
+        if (timer) {
+          clearTimeout(timer);
+        }
+        let {stdout, stderr} = getStdio(opts.isBuffer);
+        resolve({stdout, stderr, code: 0});
+        proc.kill('SIGTERM');
+      });
+    }
+
     // if we set a timeout on the child process, cut into the execution and
     // reject if the timeout is reached. Attach the stdout/stderr we currently
     // have in case it's helpful in debugging
@@ -111,7 +125,9 @@ class SubProcess extends EventEmitter {
     this.cmd = cmd;
     this.args = args;
     this.proc = null;
-    this.opts = opts;
+    this.opts = Object.assign({
+      isDaemon: true,
+    }, opts);
   }
 
   get isRunning () {
@@ -222,6 +238,17 @@ class SubProcess extends EventEmitter {
         setTimeout(() => {
           resolve();
         }, startDelay);
+      }
+
+      // kill the child process automatically if the IPC channel with the parent
+      // process is terminated and isDaemon property is not true
+      if (!this.opts.isDaemon) {
+        this.proc.on('disconnect', () => {
+          this.handleLastLines();
+          resolve();
+          this.proc.kill('SIGTERM');
+          this.proc = null;
+        });
       }
 
       // if the user has given us a timeout, start the clock for rejecting

--- a/test/subproc-specs.js
+++ b/test/subproc-specs.js
@@ -43,9 +43,9 @@ describe('SubProcess', () => {
     let x = new SubProcess('ls');
     x.args.should.eql([]);
   });
-  it('should default opts dict to {}', () => {
+  it('should default opts dict to {isDaemon: true}', () => {
     let x = new SubProcess('ls');
-    x.opts.should.eql({});
+    x.opts.should.eql({isDaemon: true});
   });
   it('should pass opts to spawn', async () => {
     const cwd = path.resolve(getFixture('.'));


### PR DESCRIPTION
The idea behind this implementation is to have a possibility of automatic clean up of child processes spawned by Appium after the parent node process is terminated to avoid unattended leftovers.

Unfortunately, I don't know yet how to create functional e2ee test for this feature, since it is necessary to kill the parent process (the node interpreter itself) in order to satisfy the condition.