### PR TITLE
Avoid an unexpected crash if any of streams is ignored and thus undefined

### DIFF
--- a/lib/teen_process.js
+++ b/lib/teen_process.js
@@ -36,24 +36,34 @@ function exec (cmd, args = [], opts = {}) {
       }
       reject(new Error(msg));
     });
-    proc.stdin.on('error', (err) => {
-      reject(new Error(`Standard input '${err.syscall}' error: ${err.stack}`));
-    });
-    proc.stdout.on('error', (err) => {
-      reject(new Error(`Standard output '${err.syscall}' error: ${err.stack}`));
-    });
-    proc.stderr.on('error', (err) => {
-      reject(new Error(`Standard error '${err.syscall}' error: ${err.stack}`));
-    });
+    if (proc.stdin) {
+      proc.stdin.on('error', (err) => {
+        reject(new Error(`Standard input '${err.syscall}' error: ${err.stack}`));
+      });
+    }
+    if (proc.stdout) {
+      proc.stdout.on('error', (err) => {
+        reject(new Error(`Standard output '${err.syscall}' error: ${err.stack}`));
+      });
+    }
+    if (proc.stderr) {
+      proc.stderr.on('error', (err) => {
+        reject(new Error(`Standard error '${err.syscall}' error: ${err.stack}`));
+      });
+    }
 
     // keep track of stdout/stderr if we haven't said not to
     if (!opts.ignoreOutput) {
-      proc.stdout.on('data', (data) => {
-        stdoutArr.push(data);
-      });
-      proc.stderr.on('data', (data) => {
-        stderrArr.push(data);
-      });
+      if (proc.stdout) {
+        proc.stdout.on('data', (data) => {
+          stdoutArr.push(data);
+        });
+      }
+      if (proc.stderr) {
+        proc.stderr.on('data', (data) => {
+          stderrArr.push(data);
+        });
+      }
     }
 
     function getStdio (isBuffer) {
@@ -199,13 +209,17 @@ class SubProcess extends EventEmitter {
         reject(err);
       });
 
-      this.proc.stdout.pipe(through(stdout => {
-        handleOutput({stdout, stderr: ''});
-      }));
+      if (this.proc.stdout) {
+        this.proc.stdout.pipe(through(stdout => {
+          handleOutput({stdout, stderr: ''});
+        }));
+      }
 
-      this.proc.stderr.pipe(through(stderr => {
-        handleOutput({stdout: '', stderr});
-      }));
+      if (this.proc.stderr) {
+        this.proc.stderr.pipe(through(stderr => {
+          handleOutput({stdout: '', stderr});
+        }));
+      }
 
       // when the proc exits, we might still have a buffer of lines we were
       // waiting on more chunks to complete. Go ahead and emit those, then


### PR DESCRIPTION
```2017-07-27 04:20:56:578 - error: [simctl] TypeError: Cannot read property 'on' of undefined
    at ../../lib/teen_process.js:39:15
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at exec (../../lib/teen_process.js:25:10)
    at callee$1$0$ (../../lib/simctl.js:38:18)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at callee$1$0 (../../lib/simctl.js:37:71)
    at simCommand$ (../../lib/simctl.js:22:18)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at simCommand (../../lib/simctl.js:12:129)
    at simExec$ (../../lib/simctl.js:37:16)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at simExec (../../lib/simctl.js:36:100)
    at getDevices$ (../../lib/simctl.js:210:26)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at getDevices (../../lib/simctl.js:210:16)
    at simExists$ (../../lib/utils.js:144:23)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at simExists (../../lib/utils.js:144:14)
    at XCUITestDriver.determineDevice$ (../../lib/driver.js:629:34)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at process._tickCallback (internal/process/next_tick.js:109:7)
 TypeError: Cannot read property 'on' of undefined
    at ../../lib/teen_process.js:39:15
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at exec (../../lib/teen_process.js:25:10)
    at callee$1$0$ (../../lib/simctl.js:38:18)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at callee$1$0 (../../lib/simctl.js:37:71)
    at simCommand$ (../../lib/simctl.js:22:18)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at simCommand (../../lib/simctl.js:12:129)
    at simExec$ (../../lib/simctl.js:37:16)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at simExec (../../lib/simctl.js:36:100)
    at getDevices$ (../../lib/simctl.js:210:26)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at getDevices (../../lib/simctl.js:210:16)
    at simExists$ (../../lib/utils.js:144:23)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at enqueueResult (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:185:17)
    at F (/usr/local/lib/node_modules/appium/node_modules/core-js/library/modules/$.export.js:30:36)
    at AsyncIterator.enqueue (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:184:12)
    at AsyncIterator.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at Object.runtime.async (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:209:12)
    at simExists (../../lib/utils.js:144:14)
    at XCUITestDriver.determineDevice$ (../../lib/driver.js:629:34)
    at tryCatch (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:67:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:315:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:100:21)
    at GeneratorFunctionPrototype.invoke (/usr/local/lib/node_modules/appium/node_modules/babel-runtime/regenerator/runtime.js:136:37)
    at process._tickCallback (internal/process/next_tick.js:109:7)
2017-07-27 04:20:56:579 - info: [debug] [simctl] Unable to get JSON device list: Cannot read property 'on' of undefined
```