### PR TITLE
Update source-map-support version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "appium-support": "^2.0.10",
     "babel-runtime": "=5.8.24",
     "shell-quote": "^1.4.3",
-    "source-map-support": "^0.2.10",
+    "source-map-support": "^0.4.18",
     "through": "^2.3.8"
   },
   "scripts": {


### PR DESCRIPTION
This `source-map-support` version seems old. This version can cause process blocking issue because uncaught exceptions which can appears when fetching `*.map` files are not handled (such as `.map` file does not exist).

I update it to the new version since https://github.com/appium/appium is using `0.4.14`.

Thanks.