### PR TITLE
Add 'shell' option to be able to run shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ The `exec` function takes some options, with these defaults:
   timeout: null,
   killSignal: 'SIGTERM',
   encoding: 'utf8',
-  ignoreOutput: false
+  ignoreOutput: false,
+  stdio: "inherit",
+  isBuffer: false,
+  shell: undefined,
 }
 ```
 

--- a/lib/teen_process.js
+++ b/lib/teen_process.js
@@ -23,13 +23,14 @@ function exec (cmd, args = [], opts = {}) {
     ignoreOutput: false,
     stdio: "inherit",
     isBuffer: false,
+    shell: undefined,
   }, opts);
 
   // this is an async function, so return a promise
   return new B((resolve, reject) => {
     // spawn the child process with options; we don't currently expose any of
     // the other 'spawn' options through the API
-    let proc = spawn(cmd, args, {cwd: opts.cwd, env: opts.env});
+    let proc = spawn(cmd, args, {cwd: opts.cwd, env: opts.env, shell: opts.shell});
     let stdoutArr = [], stderrArr = [], timer = null;
 
     // if the process errors out, reject the promise


### PR DESCRIPTION
This option will allow to run `.bat` and `.sh` files, which is sometimes needed by script, like [apksigner](https://github.com/appium/appium-adb/pull/277#issuecomment-351951434)