### PR TITLE
Add args to error message when command cannot be stopped

### DIFF
--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -5,6 +5,7 @@ import events from 'events';
 import through from 'through';
 const { EventEmitter } = events;
 import B from 'bluebird';
+import { quote } from 'shell-quote';
 
 
 class SubProcess extends EventEmitter {
@@ -176,7 +177,7 @@ class SubProcess extends EventEmitter {
 
   async stop (signal = 'SIGTERM', timeout = 10000) {
     if (!this.isRunning) {
-      throw new Error(`Can't stop process; it's not currently running (cmd: '${this.cmd} ${this.args.join(' ')}')`);
+      throw new Error(`Can't stop process; it's not currently running (cmd: '${this.cmd} ${quote(this.args)}')`);
     }
     // make sure to emit any data in our lines buffer whenever we're done with
     // the proc

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -176,7 +176,7 @@ class SubProcess extends EventEmitter {
 
   async stop (signal = 'SIGTERM', timeout = 10000) {
     if (!this.isRunning) {
-      throw new Error(`Can't stop process; it's not currently running (cmd: '${this.cmd}')`);
+      throw new Error(`Can't stop process; it's not currently running (cmd: '${this.cmd} ${this.args.join(' ')}')`);
     }
     // make sure to emit any data in our lines buffer whenever we're done with
     // the proc


### PR DESCRIPTION
The current logging is generally good, but there are cases where multiple processes may be running with the same basic command. Log all the arguments so that the exact process is distinguishable.