### PR TITLE
Add command to timeout error message

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -7,7 +7,7 @@ import B from 'bluebird';
 
 function exec (cmd, args = [], opts = {}) {
   // get a quoted representation of the command for error strings
-  let rep = quote([cmd].concat(args));
+  const rep = quote([cmd, ...args]);
 
   // extend default options; we're basically re-implementing exec's options
   // for use here with spawn under the hood

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -6,19 +6,24 @@ import through from 'through';
 const { EventEmitter } = events;
 import B from 'bluebird';
 import { quote } from 'shell-quote';
+import _ from 'lodash';
 
 
 class SubProcess extends EventEmitter {
   constructor (cmd, args = [], opts = {}) {
     super();
-    if (!cmd) throw new Error("Command is required"); // eslint-disable-line curly
-    if (typeof cmd !== "string") throw new Error("Command must be a string"); // eslint-disable-line curly
-    if (!(args instanceof Array)) throw new Error("Args must be an array"); // eslint-disable-line curly
+    if (!cmd) throw new Error('Command is required'); // eslint-disable-line curly
+    if (!_.isString(cmd)) throw new Error('Command must be a string'); // eslint-disable-line curly
+    if (!_.isArray(args)) throw new Error('Args must be an array'); // eslint-disable-line curly
+
     this.cmd = cmd;
     this.args = args;
     this.proc = null;
     this.opts = opts;
     this.expectingExit = false;
+
+    // get a quoted representation of the command for error strings
+    this.rep = quote([cmd, ...args]);
   }
 
   get isRunning () {
@@ -46,7 +51,7 @@ class SubProcess extends EventEmitter {
 
     // if the user passes a number, then we simply delay a certain amount of
     // time before returning control, rather than waiting for a condition
-    if (typeof startDetector === 'number') {
+    if (_.isNumber(startDetector)) {
       startDelay = startDetector;
       startDetector = null;
     }
@@ -155,10 +160,10 @@ class SubProcess extends EventEmitter {
 
       // if the user has given us a timeout, start the clock for rejecting
       // the promise if we take too long to start
-      if (typeof timeoutMs === "number") {
+      if (_.isNumber(timeoutMs)) {
         setTimeout(() => {
-          reject(new Error("The process did not start in the allotted time " +
-            `(${timeoutMs}ms)`));
+          reject(new Error(`The process did not start within ${timeoutMs}ms ` +
+            `(cmd: '${this.rep}')`));
         }, timeoutMs);
       }
     });
@@ -177,7 +182,7 @@ class SubProcess extends EventEmitter {
 
   async stop (signal = 'SIGTERM', timeout = 10000) {
     if (!this.isRunning) {
-      throw new Error(`Can't stop process; it's not currently running (cmd: '${this.cmd} ${quote(this.args)}')`);
+      throw new Error(`Can't stop process; it's not currently running (cmd: '${this.rep}')`);
     }
     // make sure to emit any data in our lines buffer whenever we're done with
     // the proc
@@ -187,20 +192,20 @@ class SubProcess extends EventEmitter {
       this.expectingExit = true;
       this.proc.kill(signal);
       setTimeout(() => {
-        reject(new Error(`Process didn't end after ${timeout}ms`));
+        reject(new Error(`Process didn't end after ${timeout}ms (cmd: '${this.rep}')`));
       }, timeout);
     });
   }
 
   async join (allowedExitCodes = [0]) {
     if (!this.isRunning) {
-      throw new Error("Can't join process; it's not currently running");
+      throw new Error(`Cannot join process; it is not currently running (cmd: '${this.rep}')`);
     }
 
     return new B((resolve, reject) => {
       this.proc.on('exit', (code) => {
         if (allowedExitCodes.indexOf(code) === -1) {
-          reject(new Error(`Process ended with exitcode ${code}`));
+          reject(new Error(`Process ended with exitcode ${code} (cmd: '${this.rep}')`));
         } else {
           resolve(code);
         }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "through": "^2.3.8"
   },
   "scripts": {
+    "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
+    "build": "gulp transpile",
     "prepublish": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp",

--- a/test/subproc-specs.js
+++ b/test/subproc-specs.js
@@ -115,7 +115,7 @@ describe('SubProcess', function () {
       let sd = (stdout) => { return stdout.indexOf('nothere') !== -1; };
       let s = new SubProcess('ls');
       let start = Date.now();
-      await s.start(sd, 500).should.eventually.be.rejectedWith(/did not start.+time/i);
+      await s.start(sd, 500).should.eventually.be.rejectedWith(/process did not start within/i);
       (Date.now() - start).should.be.below(600);
     });
   });
@@ -214,7 +214,7 @@ describe('SubProcess', function () {
   describe('#join', function () {
     it('should fail if the #start has not yet been called', async function () {
       const proc = new SubProcess(getFixture('sleepyproc.sh'), ['ls']);
-      await proc.join().should.eventually.be.rejectedWith(/Can't join/);
+      await proc.join().should.eventually.be.rejectedWith(/Cannot join/);
     });
 
     it('should wait until the process has been finished', async function () {


### PR DESCRIPTION
If the error message does not have the command in it, it is difficult to trace back to what process erred. And with it, the command can easily be manually run when there is a problem.