### PR TITLE
Add method to unref underlying proc

### DIFF
--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -39,14 +39,16 @@ class SubProcess extends EventEmitter {
 
   // spawn the subprocess and return control whenever we deem that it has fully
   // "started"
-  async start (startDetector = null, timeoutMs = null) {
+  async start (startDetector = null, timeoutMs = null, detach = false) {
     let startDelay = 10;
+
+    const genericStartDetector = function genericStartDetector (stdout, stderr) {
+      return stdout || stderr;
+    };
 
     // the default start detector simply returns true when we get any output
     if (startDetector === null) {
-      startDetector = (stdout, stderr) => {
-        return stdout || stderr;
-      };
+      startDetector = genericStartDetector;
     }
 
     // if the user passes a number, then we simply delay a certain amount of
@@ -54,6 +56,21 @@ class SubProcess extends EventEmitter {
     if (_.isNumber(startDetector)) {
       startDelay = startDetector;
       startDetector = null;
+    }
+
+    // if the user passes in a boolean as one of the arguments, use it for `detach`
+    if (_.isBoolean(startDetector) && startDetector) {
+      if (!this.opts.detached) {
+        throw new Error(`Unable to detach process that is not started with 'detached' option`);
+      }
+      detach = true;
+      startDetector = genericStartDetector;
+    } else if (_.isBoolean(timeoutMs) && timeoutMs) {
+      if (!this.opts.detached) {
+        throw new Error(`Unable to detach process that is not started with 'detached' option`);
+      }
+      detach = true;
+      timeoutMs = null;
     }
 
     // return a promise so we can wrap the async behavior
@@ -89,7 +106,7 @@ class SubProcess extends EventEmitter {
         // comes in chunks and a line could come in two different chunks, so
         // we have logic to handle that case (using this.lastLinePortion to
         // remember a line that started but did not finish in the last chunk)
-        for (let stream of ['stdout', 'stderr']) {
+        for (const stream of ['stdout', 'stderr']) {
           if (!data[stream]) continue; // eslint-disable-line curly
           let lines = data[stream].split("\n");
           if (lines.length > 1) {
@@ -166,6 +183,10 @@ class SubProcess extends EventEmitter {
             `(cmd: '${this.rep}')`));
         }, timeoutMs);
       }
+    }).finally(() => {
+      if (detach && this.proc) {
+        this.proc.unref();
+      }
     });
   }
 
@@ -213,7 +234,14 @@ class SubProcess extends EventEmitter {
     });
   }
 
+  /*
+   * This will only work if the process is created with the `detached` option
+   */
   detachProcess () {
+    if (!this.opts.detached) {
+      // this means that there is a misconfiguration in the calling code
+      throw new Error(`Unable to detach process that is not started with 'detached' option`);
+    }
     if (this.proc) {
       this.proc.unref();
     }

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -212,6 +212,16 @@ class SubProcess extends EventEmitter {
       });
     });
   }
+
+  detachProcess () {
+    if (this.proc) {
+      this.proc.unref();
+    }
+  }
+
+  get pid () {
+    return this.proc ? this.proc.pid : null;
+  }
 }
 
 export { SubProcess };

--- a/test/subproc-specs.js
+++ b/test/subproc-specs.js
@@ -9,10 +9,11 @@ import { getFixture } from './helpers';
 import { system } from 'appium-support';
 
 
-// Windows doesn't understand SIGHUP
-let stopSignal = system.isWindows() ? 'SIGTERM' : 'SIGHUP';
 const should = chai.should();
 chai.use(chaiAsPromised);
+
+// Windows doesn't understand SIGHUP
+const stopSignal = system.isWindows() ? 'SIGTERM' : 'SIGHUP';
 
 describe('SubProcess', function () {
   it('should throw an error if initialized without a command', function () {
@@ -307,6 +308,19 @@ describe('SubProcess', function () {
       dieCaught.should.eql(exitCaught);
       stopCaught.should.be.false;
       endCaught.should.be.false;
+    });
+  });
+
+  describe('#detachProcess', function () {
+    it('should work when process started detached', async function () {
+      const proc = new SubProcess('tail', ['-f', path.resolve(__filename)], {detached: true});
+      await proc.start();
+      proc.detachProcess();
+    });
+    it('should throw error if called when process not started detached', async function () {
+      const proc = new SubProcess('tail', ['-f', path.resolve(__filename)]);
+      await proc.start();
+      (() => proc.detachProcess()).should.throw(/Unable to detach process that is not started with 'detached' option/);
     });
   });
 });


### PR DESCRIPTION
There are places where we use `unref` (see, for instance, https://github.com/appium/appium-xcuitest-driver/blob/master/lib/utils.js#L200, https://github.com/appium/appium-xcuitest-driver/blob/master/lib/wda/iproxy.js#L58), and get the `pid` (see, for instance, https://github.com/appium/appium-xcuitest-driver/blob/master/lib/wda/utils.js#L244) on the internal `proc`. This is a bad practice.