### PR TITLE
Move non-dev dependencies to dependencies as required by lib/subprocess.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "appium-support": "^2.0.10",
+    "bluebird": "^3.5.1",
+    "lodash": "^4.17.4",
     "shell-quote": "^1.4.3",
     "source-map-support": "^0.5.3",
     "through": "^2.3.8"
@@ -55,7 +57,6 @@
     "ajv": "^6.5.3",
     "appium-gulp-plugins": "^3.1.0",
     "babel-eslint": "^10.0.0",
-    "bluebird": "^3.5.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.2.0",
@@ -64,7 +65,6 @@
     "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-promise": "^4.0.0",
     "gulp": "^4.0.0",
-    "lodash": "^4.17.4",
     "pre-commit": "^1.2.2"
   },
   "greenkeeper": {


### PR DESCRIPTION
It looks like `bluebird` and `lodash` are required in non-development files, which causes dependency issues using the new Yarn Plug n' Play features. 

Alternatively these could be moved to `peerDependencies` to allow application authors to control these packages.