### PR TITLE
Add option to inline log during exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The `exec` function takes some options, with these defaults:
   stdio: "inherit",
   isBuffer: false,
   shell: undefined,
+  logger: undefined,
 }
 ```
 
@@ -83,6 +84,10 @@ Example:
 let {stdout, stderr} = await exec('cat', [filename], {isBuffer: true});
 Buffer.isBuffer(stdout); // true
 ```
+
+The `logger` option allows stdout and stderr to be sent to a particular logger,
+as it it received. This is overridden by the `ignoreOutput` option.
+
 
 ## teen_process.SubProcess
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -3,9 +3,10 @@
 import { spawn } from 'child_process';
 import { quote } from 'shell-quote';
 import B from 'bluebird';
+import _ from 'lodash';
 
 
-function exec (cmd, args = [], opts = {}) {
+async function exec (cmd, args = [], opts = {}) {
   // get a quoted representation of the command for error strings
   const rep = quote([cmd, ...args]);
 
@@ -21,10 +22,11 @@ function exec (cmd, args = [], opts = {}) {
     stdio: 'inherit',
     isBuffer: false,
     shell: undefined,
+    logger: undefined,
   }, opts);
 
   // this is an async function, so return a promise
-  return new B((resolve, reject) => {
+  return await new B((resolve, reject) => {
     // spawn the child process with options; we don't currently expose any of
     // the other 'spawn' options through the API
     let proc = spawn(cmd, args, {cwd: opts.cwd, env: opts.env, shell: opts.shell});
@@ -59,11 +61,17 @@ function exec (cmd, args = [], opts = {}) {
       if (proc.stdout) {
         proc.stdout.on('data', (data) => {
           stdoutArr.push(data);
+          if (opts.logger && _.isFunction(opts.logger.debug)) {
+            opts.logger.debug(data);
+          }
         });
       }
       if (proc.stderr) {
         proc.stderr.on('data', (data) => {
           stderrArr.push(data);
+          if (opts.logger && _.isFunction(opts.logger.error)) {
+            opts.logger.error(data);
+          }
         });
       }
     }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -49,16 +49,8 @@ async function exec (cmd, args = [], opts = {}) {
       proc.stdout.on('error', (err) => {
         reject(new Error(`Standard output '${err.syscall}' error: ${err.stack}`));
       });
-    }
-    if (proc.stderr) {
-      proc.stderr.on('error', (err) => {
-        reject(new Error(`Standard error '${err.syscall}' error: ${err.stack}`));
-      });
-    }
-
-    // keep track of stdout/stderr if we haven't said not to
-    if (!opts.ignoreOutput) {
-      if (proc.stdout) {
+      // keep track of stdout if we have not said not to
+      if (!opts.ignoreOutput) {
         proc.stdout.on('data', (data) => {
           stdoutArr.push(data);
           if (opts.logger && _.isFunction(opts.logger.debug)) {
@@ -66,7 +58,13 @@ async function exec (cmd, args = [], opts = {}) {
           }
         });
       }
-      if (proc.stderr) {
+    }
+    if (proc.stderr) {
+      proc.stderr.on('error', (err) => {
+        reject(new Error(`Standard error '${err.syscall}' error: ${err.stack}`));
+      });
+      // keep track of stderr if we have not said not to
+      if (!opts.ignoreOutput) {
         proc.stderr.on('data', (data) => {
           stderrArr.push(data);
           if (opts.logger && _.isFunction(opts.logger.error)) {


### PR DESCRIPTION
For long-running processes we may still want to use `exec` (if we don't need the process control in `SubProcess`) but logging the output as it happens may be advantageous.