### PR TITLE
Make sure the last line logic would never cause a memory leak

### DIFF
--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -8,7 +8,9 @@ import B from 'bluebird';
 import { quote } from 'shell-quote';
 import _ from 'lodash';
 
-
+// This is needed to avoid memory leaks
+// when the process output is too long and contains
+// no line breaks
 const MAX_LINE_PORTION_LENGTH = 0xFFFF;
 
 function cutSuffix (str, suffixLength) {
@@ -126,8 +128,9 @@ class SubProcess extends EventEmitter {
           if (lines.length > 1) {
             lines[0] = this.lastLinePortion[streamName] + lines[0];
             this.lastLinePortion[streamName] = cutSuffix(_.last(lines), MAX_LINE_PORTION_LENGTH);
-            this.emit(`lines-${streamName}`, lines);
-            this.emitLines(streamName, lines);
+            const resultLines = lines.slice(0, -1);
+            this.emit(`lines-${streamName}`, resultLines);
+            this.emitLines(streamName, resultLines);
           } else {
             const currentPortion = cutSuffix(lines[0], MAX_LINE_PORTION_LENGTH);
             if (this.lastLinePortion[streamName].length + currentPortion.length > MAX_LINE_PORTION_LENGTH) {

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -98,10 +98,12 @@ class SubProcess extends EventEmitter {
 
       // this function handles output that we collect from the subproc
       const handleOutput = (data) => {
+        const streams = _.cloneDeep(data);
+        const {stdout, stderr} = streams;
         // if we have a startDetector, run it on the output so we can resolve/
         // reject and move on from start
         try {
-          if (startDetector && startDetector(data.stdout, data.stderr)) {
+          if (startDetector && startDetector(stdout, stderr)) {
             startDetector = null;
             resolve();
           }
@@ -110,26 +112,26 @@ class SubProcess extends EventEmitter {
         }
 
         // emit the actual output for whomever's listening
-        this.emit('output', data.stdout, data.stderr);
+        this.emit('output', stdout, stderr);
 
         // we also want to emit lines, but it's more complex since output
         // comes in chunks and a line could come in two different chunks, so
         // we have logic to handle that case (using this.lastLinePortion to
         // remember a line that started but did not finish in the last chunk)
-        for (const stream of ['stdout', 'stderr']) {
-          if (!data[stream]) continue; // eslint-disable-line curly
-          const lines = _.cloneDeep(data[stream].split('\n'));
+        for (const [streamName, streamData] of _.toPairs(streams)) {
+          if (!streamData) continue; // eslint-disable-line curly
+          const lines = streamData.split('\n');
           if (lines.length > 1) {
-            lines[0] = this.lastLinePortion[stream] + lines[0];
-            this.lastLinePortion[stream] = cutSuffix(lines[lines.length - 1], MAX_LINE_PORTION_LENGTH);
-            this.emit(`lines-${stream}`, lines);
-            this.emitLines(stream, lines);
+            lines[0] = this.lastLinePortion[streamName] + lines[0];
+            this.lastLinePortion[streamName] = cutSuffix(_.last(lines), MAX_LINE_PORTION_LENGTH);
+            this.emit(`lines-${streamName}`, lines);
+            this.emitLines(streamName, lines);
           } else {
             const currentPortion = cutSuffix(lines[0], MAX_LINE_PORTION_LENGTH);
-            if (this.lastLinePortion[stream].length + currentPortion.length > MAX_LINE_PORTION_LENGTH) {
-              this.lastLinePortion[stream] = currentPortion;
+            if (this.lastLinePortion[streamName].length + currentPortion.length > MAX_LINE_PORTION_LENGTH) {
+              this.lastLinePortion[streamName] = currentPortion;
             } else {
-              this.lastLinePortion[stream] += currentPortion;
+              this.lastLinePortion[streamName] += currentPortion;
             }
           }
         }

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -118,13 +118,12 @@ class SubProcess extends EventEmitter {
         // remember a line that started but did not finish in the last chunk)
         for (const stream of ['stdout', 'stderr']) {
           if (!data[stream]) continue; // eslint-disable-line curly
-          const lines = data[stream].split('\n');
+          const lines = _.cloneDeep(data[stream].split('\n'));
           if (lines.length > 1) {
-            const retLines = lines.slice(0, -1);
-            retLines[0] = this.lastLinePortion[stream] + retLines[0];
+            lines[0] = this.lastLinePortion[stream] + lines[0];
             this.lastLinePortion[stream] = cutSuffix(lines[lines.length - 1], MAX_LINE_PORTION_LENGTH);
-            this.emit(`lines-${stream}`, retLines);
-            this.emitLines(stream, retLines);
+            this.emit(`lines-${stream}`, lines);
+            this.emitLines(stream, lines);
           } else {
             const currentPortion = cutSuffix(lines[0], MAX_LINE_PORTION_LENGTH);
             if (this.lastLinePortion[stream].length + currentPortion.length > MAX_LINE_PORTION_LENGTH) {

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -9,6 +9,16 @@ import { quote } from 'shell-quote';
 import _ from 'lodash';
 
 
+const MAX_LINE_PORTION_LENGTH = 0xFFFF;
+
+function cutSuffix (str, suffixLength) {
+  return str.length > suffixLength
+    // https://bugs.chromium.org/p/v8/issues/detail?id=2869
+    ? ` ${str.substr(str.length - suffixLength)}`.substr(1)
+    : str;
+}
+
+
 class SubProcess extends EventEmitter {
   constructor (cmd, args = [], opts = {}) {
     super();
@@ -108,15 +118,20 @@ class SubProcess extends EventEmitter {
         // remember a line that started but did not finish in the last chunk)
         for (const stream of ['stdout', 'stderr']) {
           if (!data[stream]) continue; // eslint-disable-line curly
-          let lines = data[stream].split('\n');
+          const lines = data[stream].split('\n');
           if (lines.length > 1) {
-            let retLines = lines.slice(0, -1);
+            const retLines = lines.slice(0, -1);
             retLines[0] = this.lastLinePortion[stream] + retLines[0];
-            this.lastLinePortion[stream] = lines[lines.length - 1];
+            this.lastLinePortion[stream] = cutSuffix(lines[lines.length - 1], MAX_LINE_PORTION_LENGTH);
             this.emit(`lines-${stream}`, retLines);
             this.emitLines(stream, retLines);
           } else {
-            this.lastLinePortion[stream] += lines[0];
+            const currentPortion = cutSuffix(lines[0], MAX_LINE_PORTION_LENGTH);
+            if (this.lastLinePortion[stream].length + currentPortion.length > MAX_LINE_PORTION_LENGTH) {
+              this.lastLinePortion[stream] = currentPortion;
+            } else {
+              this.lastLinePortion[stream] += currentPortion;
+            }
           }
         }
       };

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -120,7 +120,9 @@ class SubProcess extends EventEmitter {
         // remember a line that started but did not finish in the last chunk)
         for (const [streamName, streamData] of _.toPairs(streams)) {
           if (!streamData) continue; // eslint-disable-line curly
-          const lines = streamData.split('\n');
+          const lines = streamData.split('\n')
+            // https://bugs.chromium.org/p/v8/issues/detail?id=2869
+            .map((x) => ` ${x}`.substr(1));
           if (lines.length > 1) {
             lines[0] = this.lastLinePortion[streamName] + lines[0];
             this.lastLinePortion[streamName] = cutSuffix(_.last(lines), MAX_LINE_PORTION_LENGTH);


### PR DESCRIPTION
The current logic is fine if we are getting a textual output with short strings separated by line breaks. Although, there will be serious memory issues if the output is binary. the PR limits the maximum size of stored strings by 64KB.