### PR TITLE
feat: pass detached option in exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The `exec` function takes some options, with these defaults:
   stdio: "inherit",
   isBuffer: false,
   shell: undefined,
+  detached: false,
   logger: undefined,
   maxStdoutBufferSize: 100 * 1024 * 1024, // 100 MB
   maxStderrBufferSize: 100 * 1024 * 1024, // 100 MB

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -26,13 +26,19 @@ async function exec (cmd, args = [], opts = {}) {
     logger: undefined,
     maxStdoutBufferSize: MAX_BUFFER_SIZE,
     maxStderrBufferSize: MAX_BUFFER_SIZE,
+    detached: false,
   }, opts);
 
   // this is an async function, so return a promise
   return await new B((resolve, reject) => {
     // spawn the child process with options; we don't currently expose any of
     // the other 'spawn' options through the API
-    let proc = spawn(cmd, args, {cwd: opts.cwd, env: opts.env, shell: opts.shell});
+    let proc = spawn(cmd, args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      shell: opts.shell,
+      detached: opts.detached,
+    });
     let stdoutArr = [], stderrArr = [], timer = null;
 
     // if the process errors out, reject the promise


### PR DESCRIPTION
Pass through the [detached option](https://nodejs.org/api/child_process.html#child_process_options_detached) to `child_process.spawn` inside `exec`.

This, at the very least, will allow us to bypass the error currently happening where `idb kill` kills the process (and, because they are attached, the appium process).

See https://github.com/appium/appium-idb/issues/18