### PR TITLE
chore: add some types

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /* eslint-disable promise/prefer-await-to-callbacks */
 
 import { spawn } from 'child_process';
@@ -8,7 +10,15 @@ import { formatEnoent } from './helpers';
 
 const MAX_BUFFER_SIZE = 100 * 1024 * 1024;
 
-async function exec (cmd, args = [], opts = {}) {
+/**
+ * Spawns a process
+ * @template {TeenProcessExecOptions} T
+ * @param {string} cmd - Program to execute
+ * @param {string[]} [args] - Arguments to pass to the program
+ * @param {T} [opts] - Options
+ * @returns {Promise<BufferProp<T> extends true ? TeenProcessExecBufferResult : TeenProcessExecStringResult>}
+ */
+async function exec (cmd, args = [], opts = /** @type {T} */({})) {
   // get a quoted representation of the command for error strings
   const rep = quote([cmd, ...args]);
 
@@ -37,14 +47,15 @@ async function exec (cmd, args = [], opts = {}) {
     let stdoutArr = [], stderrArr = [], timer = null;
 
     // if the process errors out, reject the promise
-    proc.on('error', (err) => {
+    proc.on('error', /** @param {NodeJS.ErrnoException} err */(err) => {
+      // @ts-ignore
       if (err.errno === 'ENOENT') {
         err = formatEnoent(err, cmd, opts.cwd);
       }
       reject(err);
     });
     if (proc.stdin) {
-      proc.stdin.on('error', (err) => {
+      proc.stdin.on('error', /** @param {NodeJS.ErrnoException} err */(err) => {
         reject(new Error(`Standard input '${err.syscall}' error: ${err.stack}`));
       });
     }
@@ -87,6 +98,11 @@ async function exec (cmd, args = [], opts = {}) {
       chunks: stderrArr,
     });
 
+    /**
+     * @template {boolean} U
+     * @param {U} isBuffer
+     * @returns {U extends true ? {stdout: Buffer, stderr: Buffer} : {stdout: string, stderr: string}}
+     */
     function getStdio (isBuffer) {
       let stdout, stderr;
       if (isBuffer) {
@@ -96,7 +112,7 @@ async function exec (cmd, args = [], opts = {}) {
         stdout = Buffer.concat(stdoutArr).toString(opts.encoding);
         stderr = Buffer.concat(stderrArr).toString(opts.encoding);
       }
-      return {stdout, stderr};
+      return /** @type {U extends true ? {stdout: Buffer, stderr: Buffer} : {stdout: string, stderr: string}} */({stdout, stderr});
     }
 
     // if the process ends, either resolve or reject the promise based on the
@@ -108,7 +124,7 @@ async function exec (cmd, args = [], opts = {}) {
       }
       let {stdout, stderr} = getStdio(opts.isBuffer);
       if (code === 0) {
-        resolve({stdout, stderr, code});
+        resolve(/** @type {BufferProp<T> extends true ? TeenProcessExecBufferResult : TeenProcessExecStringResult} */({stdout, stderr, code}));
       } else {
         let err = new Error(`Command '${rep}' exited with code ${code}`);
         err = Object.assign(err, {stdout, stderr, code});
@@ -135,3 +151,60 @@ async function exec (cmd, args = [], opts = {}) {
 
 export { exec };
 export default exec;
+
+/**
+ * Options on top of `SpawnOptions`, unique to `teen_process.`
+ * @typedef {Object} TeenProcessProps
+ * @property {boolean} [ignoreOutput] - Ignore & discard all output
+ * @property {boolean} [isBuffer] - Return output as a Buffer
+ * @property {TeenProcessLogger} [logger] - Logger to use for debugging
+ * @property {number} [maxStdoutBufferSize] - Maximum size of `stdout` buffer
+ * @property {number} [maxStderrBufferSize] - Maximum size of `stderr` buffer
+ * @property {BufferEncoding} [encoding='utf8'] - Encoding to use for output
+ */
+
+/**
+ * A logger object understood by {@link exec teen_process.exec}.
+ * @typedef {Object} TeenProcessLogger
+ * @property {(...args: any[]) => void} debug
+ */
+
+/**
+ * Options for {@link exec teen_process.exec}.
+ * @typedef {import('child_process').SpawnOptions & TeenProcessProps} TeenProcessExecOptions
+ */
+
+/**
+ * The value {@link exec teen_process.exec} resolves to when `isBuffer` is `false`
+ * @typedef {Object} TeenProcessExecStringResult
+ * @property {string} stdout - Stdout
+ * @property {string} stderr - Stderr
+ * @property {number?} code - Exit code
+ */
+
+/**
+ * The value {@link exec teen_process.exec} resolves to when `isBuffer` is `true`
+ * @typedef {Object} TeenProcessExecBufferResult
+ * @property {Buffer} stdout - Stdout
+ * @property {Buffer} stderr - Stderr
+ * @property {number?} code - Exit code
+ */
+
+/**
+ * Extra props {@link exec teen_process.exec} adds to its error objects
+ * @typedef {Object} TeenProcessExecErrorProps
+ * @property {string} stdout - STDOUT
+ * @property {string} stderr - STDERR
+ * @property {number?} code - Exit code
+ */
+
+/**
+ * Error thrown by {@link exec teen_process.exec}
+ * @typedef {Error & TeenProcessExecErrorProps} TeenProcessExecError
+ */
+
+/**
+ * @template {{isBuffer?: boolean}} MaybeBuffer
+ * @typedef {MaybeBuffer['isBuffer']} BufferProp
+ * @private
+ */

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,11 +5,11 @@ import fs from 'fs';
  * Decorates ENOENT error received from a spawn system call
  * with a more descriptive message, so it could be properly handled by a user.
  *
- * @param {!Error} error Original error instance. !!! The instance is mutated after
+ * @param {NodeJS.ErrnoException} error Original error instance. !!! The instance is mutated after
  * this helper function invocation
- * @param {!string} cmd Original command to execute
- * @param {?string} cwd Optional path to the current working dir
- * @return {Error} Mutated error instance with an improved description or an
+ * @param {string} cmd Original command to execute
+ * @param {string|URL?} [cwd] Optional path to the current working dir
+ * @returns {NodeJS.ErrnoException} Mutated error instance with an improved description or an
  * unchanged error instance
  */
 function formatEnoent (error, cmd, cwd = null) {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
     "precommit-test"
   ],
   "devDependencies": {
+    "@types/bluebird": "^3.5.36",
+    "@types/lodash": "^4.14.177",
+    "@types/node": "^16.11.9",
+    "@types/shell-quote": "^1.7.1",
     "appium-gulp-plugins": "^5.4.1",
     "appium-support": "^2.0.10",
     "chai": "^4.1.2",


### PR DESCRIPTION
This PR should not modify any actual code, but rather add some docstrings to describe the public API of `exec()`.

Eventually we could derive a `.d.ts` from this, or move some stuff into `.d.ts`, but this will do for now.

Note: There is a potential bug where we check if `error.errno === 'ENOENT'`, since that property is now `code`.  It may have been `errno` once upon a time.  `errno` is now a `number`.  this likely is true in all maintained versions of Node.js.  I did not attempt to address this.