### PR TITLE
chore(deps): upgrade deps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "appium"
+  "extends": "@appium/eslint-config-appium"
 }

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14, 16, 18]
 
     steps:
     - uses: actions/checkout@v2

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 'use strict';
 
 const gulp = require('gulp');
-const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
+const boilerplate = require('@appium/gulp-plugins').boilerplate.use(gulp);
 
 boilerplate({build: 'teen_process'});

--- a/index.js
+++ b/index.js
@@ -1,11 +1,1 @@
-// transpile:main
-import * as cp from 'child_process';
-import * as spIndex from './lib/subprocess';
-import * as execIndex from './lib/exec';
-
-
-const { spawn } = cp;
-const { SubProcess } = spIndex;
-const { exec } = execIndex;
-
-export { exec, spawn, SubProcess };
+module.exports = require('./build/lib/index.js');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,11 @@
+// transpile:main
+import * as cp from 'child_process';
+import * as spIndex from './subprocess';
+import * as execIndex from './exec';
+
+
+const { spawn } = cp;
+const { SubProcess } = spIndex;
+const { exec } = execIndex;
+
+export { exec, spawn, SubProcess };

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -151,6 +151,9 @@ class SubProcess extends EventEmitter {
           err = formatEnoent(err, this.cmd, this.opts?.cwd);
         }
         reject(err);
+
+        this.proc.unref();
+        this.proc = null;
       });
 
       if (this.proc.stdout) {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
   "bugs": {
     "url": "https://github.com/appium/node-teen_process/issues"
   },
-  "engines": [
-    "node"
-  ],
-  "main": "./build/index.js",
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6"
+  },
+  "main": "./index.js",
   "bin": {},
   "directories": {
     "lib": "lib"
@@ -26,7 +27,6 @@
   "files": [
     "index.js",
     "lib",
-    "build/index.js",
     "build/lib"
   ],
   "dependencies": {
@@ -53,15 +53,15 @@
     "precommit-test"
   ],
   "devDependencies": {
+    "@appium/eslint-config-appium": "^6.0.2",
+    "@appium/gulp-plugins": "^7.0.2",
+    "@appium/support": "^2.59.2",
     "@types/bluebird": "^3.5.36",
     "@types/lodash": "^4.14.177",
     "@types/node": "^17.0.0",
     "@types/shell-quote": "^1.7.1",
-    "appium-gulp-plugins": "^5.4.1",
-    "appium-support": "^2.0.10",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint-config-appium": "^4.0.0",
     "gulp": "^4.0.0",
     "pre-commit": "^1.2.2"
   }

--- a/test/exec-specs.js
+++ b/test/exec-specs.js
@@ -1,11 +1,11 @@
 // transpile:mocha
 
 import path from 'path';
-import { exec } from '..';
+import { exec } from '../lib';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { getFixture } from './helpers';
-import { system } from 'appium-support';
+import { system } from '@appium/support';
 import _ from 'lodash';
 
 

--- a/test/fixtures/bad_exit.sh
+++ b/test/fixtures/bad_exit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "foo"
-sleep 1s
+sleep 1
 1>&2 echo "bar"
 exit 1

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { system } from 'appium-support';
+import { system } from '@appium/support';
 
 
 function getFixture (fix) {

--- a/test/subproc-specs.js
+++ b/test/subproc-specs.js
@@ -2,11 +2,11 @@
 
 import B from 'bluebird';
 import path from 'path';
-import { exec, SubProcess } from '..';
+import { exec, SubProcess } from '../lib';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { getFixture } from './helpers';
-import { system } from 'appium-support';
+import { system } from '@appium/support';
 
 
 const should = chai.should();
@@ -60,11 +60,23 @@ describe('SubProcess', function () {
     lines.should.include('bad_exit.sh');
     lines.should.contain('bigbuffer.js');
     lines.should.contain('echo.sh');
+    await subproc.stop();
   });
 
   describe('#start', function () {
+    /** @type {SubProcess} */
+    let s;
+
+    afterEach(async function() {
+      if (s) {
+        try {
+          await s.stop();
+        } catch {}
+      }
+    });
+
     it('should throw an error if command fails on startup', async function () {
-      let s = new SubProcess('blargimarg');
+      s = new SubProcess('blargimarg');
       await s.start().should.eventually.be.rejected;
     });
     it('should have a default startDetector of waiting for output', async function () {
@@ -181,6 +193,7 @@ describe('SubProcess', function () {
             reject(e);
           }
         });
+
         await subproc.stop(stopSignal);
       });
     });


### PR DESCRIPTION
BREAKING CHANGE

This PR updates the dev dependencies to use `@appium/support`, `@appium/gulp-plugins` and `@appium/eslint-config-appium`, away from the unmaintained (non-scoped) packages.

Due to the requirements of these deps, it's unlikely that a dev environment older than Node.js v14 / npm v6 will work.  Thus, Node.js v8, v10, and v12 are officially dropped (though they may still work; this change should not affect the published, "production" library).

An organizational change was needed for the `@appium/gulp-plugins` upgrade; `index.js` moved to `lib/index.js`, and `index.js` is now a CJS file which re-exports `build/lib/index.js`.

In addition:

- modified some tests to ensure that child processes were being cleanly shut down
- modified the `bad_exit.sh` fixture for BSD `sleep` compat