### PR TITLE
ci: remove npm update

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,6 +33,9 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+    - run: |
+        npm ci || npm install
+      name: Install dev dependencies
     - run: npm run lint
       name: Linter
     - run: npm run test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,10 +33,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: |
-        npm i -g npm
-        npm ci || npm install
-      name: Install dev dependencies
     - run: npm run lint
       name: Linter
     - run: npm run test


### PR DESCRIPTION
since this caused:

```
Run npm i -g npm
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@10.1.0
npm ERR! notsup Not compatible with your version of node/npm: npm@10.1.0
npm ERR! notsup Required: {"node":"^18.17.0 || >=20.[5](https://github.com/appium/node-teen_process/actions/runs/6129595144/job/16637854438?pr=311#step:4:6).0"}
npm ERR! notsup Actual:   {"npm":"8.19.4","node":"v1[6](https://github.com/appium/node-teen_process/actions/runs/6129595144/job/16637854438?pr=311#step:4:7).20.2"}
```

https://github.com/appium/node-teen_process/actions/runs/6129595144/job/16637854438?pr=311

So far, latest nodejs v16 installs npm v9+ so we do not need this npm update part