### PR TITLE
fix: Restore CJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export * from './lib/index';
+module.exports = require('./build/lib');

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "license": "Apache-2.0",
   "author": "Appium Contributors",
-  "main": "./build/index.js",
-  "types": "./build/index.d.ts",
+  "main": "index.js",
+  "types": "./build/lib/index.d.ts",
   "bin": {},
   "directories": {
     "lib": "lib"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "checkJs": true
   },
   "include": [
-    "index.js",
     "lib"
   ]
 }


### PR DESCRIPTION
It looks like typescript generates ESM module by default. This requires major version bump though, so reverting