### PR TITLE
chore: Make sure we cleanup all event listeners from the spawned process instance after it is closed

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -99,10 +99,11 @@ async function exec (cmd, args = [], originalOpts = /** @type {T} */({})) {
     // if the process ends, either resolve or reject the promise based on the
     // exit code of the process. either way, attach stdout, stderr, and code.
     // Also clean up the timer if it exists
-    proc.on('close', (code) => {
+    proc.once('close', (code) => {
       if (timer) {
         clearTimeout(timer);
       }
+      proc.removeAllListeners();
       const {stdout, stderr} = getStdio(isBuffer);
       if (code === 0) {
         resolve(/** @type {BufferProp<T> extends true ? TeenProcessExecBufferResult : TeenProcessExecStringResult} */({stdout, stderr, code}));

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -197,7 +197,7 @@ class SubProcess extends EventEmitter {
       // when the proc exits, we might still have a buffer of lines we were
       // waiting on more chunks to complete. Go ahead and emit those, then
       // re-emit the exit so a listener can handle the possibly-unexpected exit
-      this.proc.on('exit', (code, signal) => {
+      this.proc.once('exit', (code, signal) => {
         this.emit('exit', code, signal);
 
         // in addition to the bare exit event, also emit one of three other
@@ -213,6 +213,7 @@ class SubProcess extends EventEmitter {
 
         // finally clean up the proc and make sure to reset our exit
         // expectations
+        this.proc?.removeAllListeners();
         this.proc = null;
         this.expectingExit = false;
       });

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -216,7 +216,7 @@ class SubProcess extends EventEmitter {
       });
 
       this.proc.once('close', () => {
-        // finally clean up the proc and
+        // finally clean up the proc
         this.proc?.removeAllListeners();
         this.proc = null;
       });

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -197,7 +197,7 @@ class SubProcess extends EventEmitter {
       // when the proc exits, we might still have a buffer of lines we were
       // waiting on more chunks to complete. Go ahead and emit those, then
       // re-emit the exit so a listener can handle the possibly-unexpected exit
-      this.proc.once('exit', (code, signal) => {
+      this.proc.on('exit', (code, signal) => {
         this.emit('exit', code, signal);
 
         // in addition to the bare exit event, also emit one of three other
@@ -211,11 +211,14 @@ class SubProcess extends EventEmitter {
         }
         this.emit(event, code, signal);
 
-        // finally clean up the proc and make sure to reset our exit
-        // expectations
+        // make sure to reset our exit expectations
+        this.expectingExit = false;
+      });
+
+      this.proc.once('close', () => {
+        // finally clean up the proc and
         this.proc?.removeAllListeners();
         this.proc = null;
-        this.expectingExit = false;
       });
 
       // if the user hasn't given us a startDetector, instead just resolve


### PR DESCRIPTION
This helps the GC to release the memory faster