### PR TITLE
feat: [subprocess] support output as buffer

### DIFF
--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -181,12 +181,16 @@ class SubProcess extends EventEmitter {
       const encoding = this.opts.encoding || 'utf8';
 
       if (this.proc.stdout) {
-        this.proc.stdout.on('data', (chunk) => handleOutput({stdout: isBuffer ? chunk : chunk.toString(encoding), stderr: ''}));
+        this.proc.stdout.on('data', (chunk) =>
+          handleOutput({stdout: isBuffer ? chunk : chunk.toString(encoding), stderr: ''}),
+        );
         handleStreamLines('stdout', this.proc.stdout);
       }
 
       if (this.proc.stderr) {
-        this.proc.stderr.on('data', (chunk) => handleOutput({stdout: '', stderr: isBuffer ? chunk : chunk.toString(encoding)}));
+        this.proc.stderr.on('data', (chunk) =>
+          handleOutput({stdout: '', stderr: isBuffer ? chunk : chunk.toString(encoding)}),
+        );
         handleStreamLines('stderr', this.proc.stderr);
       }
 

--- a/lib/subprocess.js
+++ b/lib/subprocess.js
@@ -126,13 +126,6 @@ class SubProcess extends EventEmitter {
       // actually spawn the subproc
       this.proc = spawn(this.cmd, this.args, this.opts);
 
-      if (this.proc.stdout) {
-        this.proc.stdout.setEncoding(this.opts.encoding || 'utf8');
-      }
-      if (this.proc.stderr) {
-        this.proc.stderr.setEncoding(this.opts.encoding || 'utf8');
-      }
-
       // this function handles output that we collect from the subproc
       /**
        *
@@ -184,13 +177,16 @@ class SubProcess extends EventEmitter {
         });
       };
 
+      const isBuffer = Boolean(this.opts.isBuffer);
+      const encoding = this.opts.encoding || 'utf8';
+
       if (this.proc.stdout) {
-        this.proc.stdout.on('data', (chunk) => handleOutput({stdout: chunk.toString(), stderr: ''}));
+        this.proc.stdout.on('data', (chunk) => handleOutput({stdout: isBuffer ? chunk : chunk.toString(encoding), stderr: ''}));
         handleStreamLines('stdout', this.proc.stdout);
       }
 
       if (this.proc.stderr) {
-        this.proc.stderr.on('data', (chunk) => handleOutput({stdout: '', stderr: chunk.toString()}));
+        this.proc.stderr.on('data', (chunk) => handleOutput({stdout: '', stderr: isBuffer ? chunk : chunk.toString(encoding)}));
         handleStreamLines('stderr', this.proc.stderr);
       }
 

--- a/test/subproc-specs.js
+++ b/test/subproc-specs.js
@@ -2,6 +2,7 @@ import B from 'bluebird';
 import path from 'path';
 import {exec, SubProcess} from '../lib';
 import {getFixture} from './helpers';
+import _ from 'lodash';
 
 // Windows doesn't understand SIGHUP
 const stopSignal = process.platform === 'win32' ? 'SIGTERM' : 'SIGHUP';
@@ -188,6 +189,17 @@ describe('SubProcess', function () {
         });
         await subproc.start();
       });
+    });
+    it('should get output as buffer', async function () {
+      const stdout = await new B(async (resolve) => {
+        subproc = new SubProcess(getFixture('echo'), ['foo'], {isBuffer: true});
+        subproc.on('output', resolve);
+        await subproc.start();
+      });
+      _.isString(stdout).should.be.false;
+      _.isBuffer(stdout).should.be.true;
+
+      stdout.toString().trim().should.eql('foo');
     });
 
     it('should get output by lines', async function () {


### PR DESCRIPTION
It provides a buffer output so that encoding can be handled directly at the usage site.