### PR TITLE
ci: run on all Node LTS versions instead of only active

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.generate-matrix.outputs.active }}
+      versions: ${{ steps.generate-matrix.outputs.lts }}
     steps:
-    - name: Select all active LTS versions of Node.js
+    - name: Select all current LTS versions of Node.js
       id: generate-matrix
       uses: msimerson/node-lts-versions@v1
 


### PR DESCRIPTION
As same as https://github.com/appium/appium/pull/21185