### PR TITLE
feat: Bump Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "source-map-support": "^0.x"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0.0",
-    "@appium/tsconfig": "^0.x",
-    "@appium/types": "^0.x",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
+    "@appium/tsconfig": "^1.0.0-rc.1",
+    "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/bluebird": "^3.5.42",
@@ -74,7 +74,7 @@
     "ts-node": "^10.9.1"
   },
   "engines": {
-    "node": "^16.13.0 || >=18.0.0",
-    "npm": ">=8"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to `^20.19.0 || ^22.12.0 || >=24.0.0`
BREAKING CHANGE: Required npm version has been bumped to `>=10`