### PR TITLE
chore: replace bluebird with native promises

### DIFF
--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -1,6 +1,5 @@
 import {spawn} from 'node:child_process';
 import {quote} from 'shell-quote';
-import B from 'bluebird';
 import _ from 'lodash';
 import {formatEnoent} from './helpers';
 import {CircularBuffer, MAX_BUFFER_SIZE} from './circular-buffer';
@@ -69,7 +68,7 @@ export async function exec<T extends TeenProcessExecOptions = TeenProcessExecOpt
   const opts = _.defaults({}, originalOpts, defaults) as T;
   const isBuffer = Boolean(opts.isBuffer);
 
-  return await new B<TeenProcessExecResult<BufferProp<T>>>((resolve, reject) => {
+  return await new Promise<TeenProcessExecResult<BufferProp<T>>>((resolve, reject) => {
     const proc = spawn(cmd, args, {cwd: opts.cwd, env: opts.env, shell: opts.shell});
     const stdoutBuffer = new CircularBuffer(opts.maxStdoutBufferSize);
     const stderrBuffer = new CircularBuffer(opts.maxStderrBufferSize);

--- a/lib/subprocess.ts
+++ b/lib/subprocess.ts
@@ -1,7 +1,6 @@
 import {spawn} from 'node:child_process';
 import type {ChildProcess} from 'node:child_process';
 import {EventEmitter} from 'node:events';
-import B from 'bluebird';
 import {quote} from 'shell-quote';
 import _ from 'lodash';
 import {formatEnoent} from './helpers';
@@ -147,7 +146,7 @@ export class SubProcess<
       timeoutMs = null;
     }
 
-    return await new B<void>((resolve, reject) => {
+    return await new Promise<void>((resolve, reject) => {
       this.proc = spawn(this.cmd, this.args, this.opts);
 
       const handleOutput = (streams: {
@@ -275,7 +274,7 @@ export class SubProcess<
     if (!this.isRunning) {
       throw new Error(`Can't stop process; it's not currently running (cmd: '${this.rep}')`);
     }
-    return await new B<void>((resolve, reject) => {
+    return await new Promise<void>((resolve, reject) => {
       this.proc?.on('close', () => resolve());
       this.expectingExit = true;
       this.proc?.kill(signal);
@@ -307,7 +306,7 @@ export class SubProcess<
       throw new Error(`Cannot join process; it is not currently running (cmd: '${this.rep}')`);
     }
 
-    return await new B<number | null>((resolve, reject) => {
+    return await new Promise<number | null>((resolve, reject) => {
       this.proc?.on('exit', (code: number | null) => {
         if (code !== null && !allowedExitCodes.includes(code)) {
           reject(new Error(`Process ended with exitcode ${code} (cmd: '${this.rep}')`));

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "singleQuote": true
   },
   "dependencies": {
-    "bluebird": "^3.7.2",
     "lodash": "^4.17.21",
     "shell-quote": "^1.8.1"
   },
@@ -57,7 +56,6 @@
     "@appium/types": "^1.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@types/bluebird": "^3.5.42",
     "@types/lodash": "^4.14.202",
     "@types/mocha": "10.0.10",
     "@types/node": "^25.0.0",

--- a/test/subproc-specs.ts
+++ b/test/subproc-specs.ts
@@ -1,4 +1,3 @@
-import B from 'bluebird';
 import path from 'path';
 import {exec, SubProcess} from '../lib';
 import {getFixture} from './helpers';
@@ -58,7 +57,7 @@ describe('SubProcess', function () {
       lines = lines.concat(newLines);
     });
     await subproc.start(0);
-    await B.delay(50);
+    await new Promise((resolve) => setTimeout(resolve, 50));
     expect(lines).to.include('bad_exit.sh');
     expect(lines).to.contain('bigbuffer.js');
     expect(lines).to.contain('echo.sh');
@@ -108,7 +107,7 @@ describe('SubProcess', function () {
       });
       await s.start(0);
       expect(hasData).to.be.false;
-      await B.delay(1200);
+      await new Promise((resolve) => setTimeout(resolve, 1200));
       expect(hasData).to.be.true;
     });
     it('should fail even with a start timeout of 0 when command is bad', async function () {
@@ -160,46 +159,40 @@ describe('SubProcess', function () {
       } catch {}
     });
     it('should get output as params', async function () {
-      await expect(new B(async (resolve, reject) => {
-        subproc = new SubProcess(getFixture('sleepyproc'), [
-          'ls',
-          path.resolve(__dirname),
-        ]);
-        subproc.on('output', (stdout: string | Buffer) => {
-          if (stdout && typeof stdout === 'string' && !stdout.includes('subproc-specs')) {
-            reject();
-          } else {
-            resolve(undefined);
-          }
-        });
-        await subproc.start();
-      })).to.eventually.not.be.rejected;
+      subproc = new SubProcess(getFixture('sleepyproc'), ['ls', path.resolve(__dirname)]);
+      const output: (string | Buffer)[] = [];
+      subproc.on('output', (stdout: string | Buffer) => {
+        output.push(stdout);
+      });
+      await subproc.start();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(_.isString(output[0])).to.be.true;
+      expect(output[0]).to.include('subproc-specs');
     });
     it('should get output as params with args', async function () {
-      await new B(async (resolve, reject) => {
-        subproc = new SubProcess(getFixture('echo'), ['foo', 'bar']);
-        subproc.on('output', (stdout: string | Buffer, stderr?: string | Buffer) => {
-          if (stderr && typeof stderr === 'string' && !stderr.includes('bar')) {
-            reject();
-          } else {
-            resolve(undefined);
-          }
-        });
-        await subproc.start();
+      subproc = new SubProcess(getFixture('echo'), ['foo', 'bar']);
+      const outputs: Array<{stdout: string | Buffer, stderr: string | Buffer}> = [];
+      subproc.on('output', (stdout: string | Buffer, stderr: string | Buffer) => {
+        // We expect two invocations, one with stdout and one with stderr
+        outputs.push({stdout, stderr});
       });
+      await subproc.start();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(outputs.length).to.be.above(0);
+      expect(outputs[0].stdout.toString().trim()).to.eql('foo');
+      expect(outputs[1].stderr.toString().trim()).to.eql('bar');
     });
     it('should get output as buffer', async function () {
-      const stdout = await new B<Buffer>(async (resolve) => {
-        subproc = new SubProcess(getFixture('echo'), ['foo'], {isBuffer: true});
-        subproc.on('output', resolve);
-        await subproc.start();
+      subproc = new SubProcess(getFixture('echo'), ['foo'], {isBuffer: true});
+      const output: (string | Buffer)[] = [];
+      subproc.on('output', (stdout: string | Buffer) => {
+        output.push(stdout);
       });
-      expect(_.isString(stdout)).to.be.false;
-      expect(_.isBuffer(stdout)).to.be.true;
-
-      expect(stdout.toString().trim()).to.eql('foo');
+      await subproc.start();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(_.isBuffer(output[0])).to.be.true;
+      expect(output[0].toString().trim()).to.eql('foo');
     });
-
     it('should get output by lines', async function () {
       subproc = new SubProcess('ls', [path.resolve(__dirname)]);
       let lines: string[] = [];
@@ -207,7 +200,7 @@ describe('SubProcess', function () {
         lines = lines.concat(newLines);
       });
       await subproc.start(0);
-      await B.delay(50);
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(lines).to.eql([
         'circular-buffer-specs.ts',
         'exec-specs.ts',
@@ -220,20 +213,14 @@ describe('SubProcess', function () {
 
   describe('#stop', function () {
     it('should send the right signal to stop a proc', async function () {
-      return await new B(async (resolve, reject) => {
-        const subproc = new SubProcess('tail', ['-f', path.resolve(__filename)]);
-        await subproc.start();
-        subproc.on('exit', (code: number | null, signal: string | null) => {
-          try {
-            expect(signal).to.equal(stopSignal);
-            resolve(undefined);
-          } catch (e) {
-            reject(e);
-          }
-        });
-
-        await subproc.stop(stopSignal);
+      const subproc = new SubProcess('tail', ['-f', path.resolve(__filename)]);
+      let exitSignal: string | null;
+      subproc.on('exit', (code: number | null, signal: string | null) => {
+        exitSignal = signal;
       });
+      await subproc.start();
+      await subproc.stop(stopSignal);
+      expect(exitSignal!).to.eql(stopSignal);
     });
 
     it('should time out if stop doesnt complete fast enough', async function () {
@@ -263,7 +250,7 @@ describe('SubProcess', function () {
       const subproc = new SubProcess('ls');
       await expect(subproc.stop()).to.eventually.be.rejectedWith(/Can't stop/);
       await subproc.start();
-      await B.delay(10);
+      await new Promise((resolve) => setTimeout(resolve, 10));
       await expect(subproc.stop()).to.eventually.be.rejectedWith(/Can't stop/);
     });
   });

--- a/test/subproc-specs.ts
+++ b/test/subproc-specs.ts
@@ -165,7 +165,7 @@ describe('SubProcess', function () {
         output.push(stdout);
       });
       await subproc.start();
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(_.isString(output[0])).to.be.true;
       expect(output[0]).to.include('subproc-specs');
     });
@@ -177,10 +177,10 @@ describe('SubProcess', function () {
         outputs.push({stdout, stderr});
       });
       await subproc.start();
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(outputs.length).to.be.above(0);
-      expect(outputs[0].stdout.toString().trim()).to.eql('foo');
-      expect(outputs[1].stderr.toString().trim()).to.eql('bar');
+      expect(outputs.some((o) => o.stdout?.toString().trim() === 'foo')).to.be.true;
+      expect(outputs.some((o) => o.stderr?.toString().trim() === 'bar')).to.be.true;
     });
     it('should get output as buffer', async function () {
       subproc = new SubProcess(getFixture('echo'), ['foo'], {isBuffer: true});
@@ -189,7 +189,7 @@ describe('SubProcess', function () {
         output.push(stdout);
       });
       await subproc.start();
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 50));
       expect(_.isBuffer(output[0])).to.be.true;
       expect(output[0].toString().trim()).to.eql('foo');
     });


### PR DESCRIPTION
This project only uses Bluebird for the `new B` constructor, as well as `B.delay`. Both were fairly straightforward to replace, but tests were a different story.

Several tests were calling `new B` with an async executor function, and changing this to `new Promise` triggered the ESLint rule `no-async-promise-executor`. Now the affected tests have been rewritten into a more readable fixed delay approach, which was already used in the `should get output by lines` test.

Changes also revealed that the `should get output as params with args` test was improperly validating the output - the condition `if (stderr && typeof stderr === 'string' && !stderr.includes('bar'))` fails on the first invocation due to `stderr` being an empty string, which unexpectedly causes the test to pass. I have fixed this test's behavior as well.