### PR TITLE
feat: Allow to pass uid and gid options to exec

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,6 +17,8 @@ jobs:
     uses: appium/appium-workflows/.github/workflows/node-lts-matrix.yml@main
 
   test:
+    env:
+      CI: 'true'
     needs:
     - node_matrix
     strategy:

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   build:
+    env:
+      CI: 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -66,9 +66,10 @@ export async function exec<T extends TeenProcessExecOptions = TeenProcessExecOpt
 
   const opts = _.defaults({}, originalOpts, defaults) as T;
   const isBuffer = Boolean(opts.isBuffer);
+  const spawnOpts = buildSpawnOptions(opts, originalOpts);
 
   return await new Promise<TeenProcessExecResult<BufferProp<T>>>((resolve, reject) => {
-    const proc = spawn(cmd, args, {cwd: opts.cwd, env: opts.env, shell: opts.shell});
+    const proc = spawn(cmd, args, spawnOpts);
     const stdoutBuffer = new CircularBuffer(opts.maxStdoutBufferSize);
     const stderrBuffer = new CircularBuffer(opts.maxStderrBufferSize);
     let timer: NodeJS.Timeout | null = null;
@@ -158,4 +159,20 @@ export async function exec<T extends TeenProcessExecOptions = TeenProcessExecOpt
       }, opts.timeout);
     }
   });
+}
+
+function buildSpawnOptions<T extends TeenProcessExecOptions>(opts: T, originalOpts: T) {
+  return {
+    cwd: opts.cwd,
+    env: opts.env,
+    shell: opts.shell,
+    argv0: opts.argv0,
+    uid: opts.uid,
+    gid: opts.gid,
+    detached: opts.detached,
+    windowsHide: opts.windowsHide,
+    windowsVerbatimArguments: opts.windowsVerbatimArguments,
+    signal: opts.signal,
+    ...(Object.prototype.hasOwnProperty.call(originalOpts, 'stdio') ? {stdio: opts.stdio} : {}),
+  };
 }

--- a/test/exec-specs.ts
+++ b/test/exec-specs.ts
@@ -180,4 +180,32 @@ describe('exec', function () {
       }
     });
   });
+
+  it('[manual] should be able to run command as non-sudo user when parent runs as sudo', async function () {
+    if (process.platform === 'win32' || process.env.CI !== undefined) {
+      this.skip();
+    }
+
+    if (!process.getuid || process.getuid() !== 0) {
+      this.skip();
+    }
+
+    const sudoUid = process.env.SUDO_UID;
+    const sudoGid = process.env.SUDO_GID;
+    if (!sudoUid || !sudoGid) {
+      this.skip();
+    }
+
+    const targetUid = Number(sudoUid);
+    const targetGid = Number(sudoGid);
+    const {stdout, code} = await exec('id', ['-u'], {
+      uid: targetUid,
+      gid: targetGid,
+      stdio: 'pipe',
+    });
+
+    expect(code).to.equal(0);
+    expect(stdout.trim()).to.equal(String(targetUid));
+    expect(targetUid).to.not.equal(0);
+  });
 });


### PR DESCRIPTION
This is necessary to tune node-devicectl and execute devicectl as non-root user even if node process is executed from root.